### PR TITLE
Update Dart constraints to support Dart 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: week_of_year
 description: Adds extension method to get the ISO 8601 week of year from a date
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/KadaDev/week_of_year
 repository: https://github.com/KadaDev/week_of_year
 issue_tracker: https://github.com/KadaDev/week_of_year/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dev_dependencies:
-  test: ^1.16.0
+  test: ^1.21.0


### PR DESCRIPTION
This PR widens constraints for Dart version to support Dart >= 3 versions.

Also updated `test` dependency, but not to the latest version to not raise the min Dart version to 3.0.0 as there is no reason for that, considering the functionality of the package.